### PR TITLE
Update logback pattern and remove status listener

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,12 +1,11 @@
 <configuration>
-    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- Set the level to DEBUG to enable debug logs -->
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} |-%level in %logger - %msg%n</pattern>
+            <pattern>[%d{HH:mm:ss}] [%level] %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Simplified the logging pattern for console output to improve readability. Removed the unused status listener to clean up the configuration file.