### PR TITLE
Add SizeRoute for handling size requests

### DIFF
--- a/src/main/java/net/thenextlvl/arkitektonika/Arkitektonika.java
+++ b/src/main/java/net/thenextlvl/arkitektonika/Arkitektonika.java
@@ -81,6 +81,7 @@ public class Arkitektonika {
         new DownloadRoute(this).register();
         new ExpirationRoute(this).register();
         new RenameRoute(this).register();
+        new SizeRoute(this).register();
         new UploadRoute(this).register();
     }
 

--- a/src/main/java/net/thenextlvl/arkitektonika/routes/SizeRoute.java
+++ b/src/main/java/net/thenextlvl/arkitektonika/routes/SizeRoute.java
@@ -1,0 +1,34 @@
+package net.thenextlvl.arkitektonika.routes;
+
+import io.javalin.http.Context;
+import lombok.RequiredArgsConstructor;
+import net.thenextlvl.arkitektonika.Arkitektonika;
+
+@RequiredArgsConstructor
+public class SizeRoute {
+    private final Arkitektonika arkitektonika;
+
+    public void register() {
+        arkitektonika.javalin().get("/size/{key}", this::get);
+        arkitektonika.javalin().options("/size/{key}", context -> {
+            context.header("Access-Control-Allow-Methods", "GET");
+            context.status(204);
+        });
+    }
+
+    private void get(Context context) {
+        context.future(() -> arkitektonika.schematicController()
+                .getByDownloadKey(context.pathParam("key"))
+                .thenAccept(optional -> optional.ifPresentOrElse(schematic -> {
+                    context.result(String.valueOf(schematic.data().length));
+                    context.status(200);
+                }, () -> {
+                    context.result("File not found");
+                    context.status(404);
+                })).exceptionally(throwable -> {
+                    context.result(throwable.getMessage());
+                    context.status(500);
+                    return null;
+                }));
+    }
+}


### PR DESCRIPTION
Introduces a new route, SizeRoute, that processes GET requests to fetch the size of a schematic by its download key. It includes proper CORS headers and handles various response statuses: 200 for success, 404 for not found, and 500 for server errors.