### PR TITLE
Fix name update in RenameRoute

### DIFF
--- a/src/main/java/net/thenextlvl/arkitektonika/routes/RenameRoute.java
+++ b/src/main/java/net/thenextlvl/arkitektonika/routes/RenameRoute.java
@@ -20,6 +20,7 @@ public class RenameRoute {
         arkitektonika.schematicController()
                 .getByDeletionKey(context.pathParam("key"))
                 .thenAccept(optional -> optional.ifPresentOrElse(schematic -> {
+                    schematic.name(context.pathParam("name"));
                     arkitektonika.dataController().renameSchematic(schematic);
                     context.result("File was renamed");
                     context.status(200);


### PR DESCRIPTION
Re-add missing line to update schematic name in the database. This ensures the file name is correctly changed and the response accurately reflects the renaming operation.